### PR TITLE
improved support for non-class based features

### DIFF
--- a/src/Models/FeatureSegment.php
+++ b/src/Models/FeatureSegment.php
@@ -35,7 +35,11 @@ class FeatureSegment extends Model
 
     public function title(): Attribute
     {
-        return Attribute::get(fn () => class_exists($this->feature) ? $this->feature::title() : '(Feature Deleted)');
+        return Attribute::get(
+            fn () => class_exists($this->feature)
+                ? $this->feature::title()
+                : str($this->feature)->headline()
+        );
     }
 
     public function description(): Attribute
@@ -54,7 +58,7 @@ class FeatureSegment extends Model
         return collect(Feature::all())
             ->map(fn ($value, $key) => [
                 'id' => $key,
-                'name' => $name = str(class_basename($key))->snake()->replace('_', ' ')->title()->toString(),
+                'name' => $name = str(class_basename($key))->headline()->toString(),
                 'state' => $value,
                 'description' => "This feature covers $name on the mobile app.",
             ])

--- a/src/Traits/WithFeatureResolver.php
+++ b/src/Traits/WithFeatureResolver.php
@@ -27,7 +27,7 @@ trait WithFeatureResolver
 
     public static function title(): string
     {
-        return str(class_basename(self::class))->snake()->replace('_', ' ')->title()->toString();
+        return str(class_basename(self::class))->headline()->toString();
     }
 
     public static function description(): string


### PR DESCRIPTION
The package assumes all feature segments are backed by a class, and thus segments with missing classes have the title of `(Feature Deleted)`.

This PR comes with a little update which displays the name of the feature as it is stored in the DB, if it doesn't have a feature class.