### PR TITLE
Boot feature discover only if feature folder exist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,11 @@
     ],
     "require": {
         "php": "^8.2",
-        "spatie/laravel-package-tools": "^1.14.0",
         "filament/filament": "^3.0",
+        "illuminate/contracts": "^10.0|^11.0",
         "laravel/pennant": "^1.10",
-        "illuminate/contracts": "^10.0|^11.0"
+        "spatie/laravel-package-tools": "^1.14.0",
+        "symfony/finder": "*"
     },
     "require-dev": {
         "laravel/pint": "^1.0",

--- a/src/FeatureFlagPluginServiceProvider.php
+++ b/src/FeatureFlagPluginServiceProvider.php
@@ -5,6 +5,7 @@ namespace Stephenjude\FilamentFeatureFlag;
 use Laravel\Pennant\Feature;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
+use Symfony\Component\Finder\Finder;
 
 class FeatureFlagPluginServiceProvider extends PackageServiceProvider
 {
@@ -18,6 +19,14 @@ class FeatureFlagPluginServiceProvider extends PackageServiceProvider
 
     public function bootingPackage()
     {
-        Feature::discover();
+        $finder = new Finder();
+        $finder->directories()->name('Feature')->in(app_path());
+        /**
+        * `Feature` folder are required by the `laravel-pennant` if using a `discovery` method
+         * Boot only the Feature::discovers() if the Feature folder in app folder of laravel is existing.
+         */
+        if($finder->hasResults()) {
+            Feature::discover();
+        }
     }
 }


### PR DESCRIPTION
This PR will ensure that the `Feature` folder in the app exists before the `discover` method of `Laravel Pennat` boot.

Close #18 