### PR TITLE
Allow features to override the default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,49 @@ class WalletFunding
 }
 ```
 
+## Overriding Default Values per Feature
+
+If you need more control over the default value of a feature, you can either add a `defaultValue` property.
+
+```php
+<?php
+
+namespace App\Features;
+
+use Stephenjude\FilamentFeatureFlag\Traits\WithFeatureResolver;
+
+class WalletFunding
+{
+    use WithFeatureResolver;
+
+    protected bool $defaultValue = false;
+}
+```
+
+Or a `defineValue` method.
+
+```php
+<?php
+
+namespace App\Features;
+
+use Stephenjude\FilamentFeatureFlag\Traits\WithFeatureResolver;
+
+class WalletFunding
+{
+    use WithFeatureResolver;
+
+    protected function defaultValue(mixed $scope): bool
+    {
+        return false;
+    }
+}
+```
+
+The result of these methods will get cast to a boolean.
+
+If neither are defined, the default value gets fetched from the `filament-feature-flags.default` config entry.
+
 ## Feature Segmentation 
 By default, this package resolves scope using the `App\Models\User` model and the default segment applies features for individual or group of users by email.
 


### PR DESCRIPTION
This PR adds the possibility for features to define their own default value.

The default value defined in the config file can potentially not be a valid initial value for some flags.

This is particularly handy for feature flags that disable in-development tasks and still allowing developers to ship constantly or allow a subset of users access without needing to enable every single flag every time.